### PR TITLE
Telegram update, copyrights from 2022

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,7 +78,7 @@ layout: default
         {{ content }}
     </div>
     <footer style="font-family: 'Computer Modern Serif', serif">
-        Copyright &copy; {{ site.time | date: '%Y' }}. {{ site.domain }}.
+        Copyright &copy; 2022 - {{ site.time | date: '%Y' }}. {{ site.domain }}.
     </footer>
 </section>
 <script>var disqus_shortname = 'news-eolang-org';</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@ layout: default
                     <img width="24px" height="24px"
                          src="https://cdn.jsdelivr.net/npm/simple-icons@3.13.0/icons/twitter.svg">
                 </a></li>
-                <li><a class="class" href="https://t.me/h1alexbel">
+                <li><a class="class" href="https://t.me/h1alexbeltalks">
                     <img width="24px" height="24px"
                          src="https://cdn.jsdelivr.net/npm/simple-icons@3.13.0/icons/telegram.svg">
                 </a></li>


### PR DESCRIPTION
closes #116 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the default.html layout file by changing the Telegram link and updating the copyright year.

### Detailed summary:
- Updated Telegram link to `https://t.me/h1alexbeltalks`
- Updated copyright year to `2022`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->