### PR TITLE
sort off

### DIFF
--- a/contents.md
+++ b/contents.md
@@ -19,7 +19,7 @@ Total: {{ site.posts.size }}.
 
 This is a full list of all blog posts published:
   <ul class="categories-list">
-    {% assign sorted_posts = site.posts | sort: 'date' %}{% for post in sorted_posts %}
+    {% assign sorted_posts = site.posts %}{% for post in sorted_posts %}
       <div class="posts-list-item">
           <span class="posts-list-item-name float-left"><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></span>
         <span class="posts-list-item-date float-right">{{ post.date | date: "%Y-%m-%d" }}</span>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `sort` method from the `sorted_posts` variable which orders blog posts by date. 

### Detailed summary:
- Removed `sort` method from `sorted_posts` variable
- Blog posts are no longer sorted by date in the `categories-list` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->