### PR TITLE
share buttons borders

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -65,8 +65,8 @@ layout: default
             </ul>
             <div class="buttons notranslate desktop-only">
                 <nav class="share">
-                    <a href="https://news.ycombinator.com/submit">Hacker News</a>
-                    <a href="https://twitter.com/share?url={{ site.url }}{{ page.url }}&amp;text={{ page.title | cgi_escape }}">Twitter</a>
+                    <a href="https://news.ycombinator.com/submit">Hacker News</a> |
+                    <a href="https://twitter.com/share?url={{ site.url }}{{ page.url }}&amp;text={{ page.title | cgi_escape }}">Twitter</a> |
                     <a href="https://www.linkedin.com/cws/share?url={{ site.url }}{{ page.url }}">LinkedIn</a>
                 </nav>
             </div>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a vertical line separator between the Hacker News and Twitter share buttons on the post layout.

### Detailed summary
- Added `|` separator between Hacker News and Twitter share buttons in the `post.html` layout.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->