### PR TITLE
disqs url

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -87,7 +87,7 @@ layout: default
             };
             (function () {
                 var d = document, s = d.createElement('script');
-                s.src = '//ru-yegor256-com.disqus.com/embed.js';
+                s.src = 'https://h1alexbel.github.io.disqus.com/embed.js';
                 s.setAttribute('data-timestamp', +new Date());
                 (d.head || d.body).appendChild(s);
             })();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the Disqus embed script URL in the post.html layout file.

### Detailed summary
- Changed the Disqus embed script URL from `//ru-yegor256-com.disqus.com/embed.js` to `https://h1alexbel.github.io.disqus.com/embed.js`
- The change was made to ensure that the Disqus comments section loads correctly on the website.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->