### PR TITLE
disqs url

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -87,7 +87,7 @@ layout: default
             };
             (function () {
                 var d = document, s = d.createElement('script');
-                s.src = 'https://h1alexbel.github.io.disqus.com/embed.js';
+                s.src = 'https://h1alexbel-blog.disqus.com/embed.js';
                 s.setAttribute('data-timestamp', +new Date());
                 (d.head || d.body).appendChild(s);
             })();


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the source URL for the Disqus embed script in `_layouts/post.html`.

### Detailed summary:

- Changes the source URL for the Disqus embed script in `_layouts/post.html`.
- The new URL points to `https://h1alexbel-blog.disqus.com/embed.js` instead of `https://h1alexbel.github.io.disqus.com/embed.js`.
- The script is appended to the `head` or `body` element of the document with a `data-timestamp` attribute set to the current date and time.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->