### PR TITLE
tags

### DIFF
--- a/contents.md
+++ b/contents.md
@@ -6,12 +6,10 @@ permalink: contents.html
 ---
 [```arc```](/tag/arc.html)
 [```devops```](/tag/devops.html)
+[```github```](/tag/github.html)
 [```java```](/tag/java.html)
-[```k8s```](/tag/k8s.html)
 [```maintainability```](/tag/maintainability.html)
 [```microservices```](/tag/microservices.html)
-[```nosql```](/tag/nosql.html)
-[```oss```](/tag/oss.html)
 [```pets```](/tag/pets.html)
 [```quality```](/tag/quality.html)
 [```reactive```](/tag/reactive.html)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `github` tag and removes the `k8s`, `nosql`, and `oss` tags from `contents.md`.

### Detailed summary:
- Added `github` tag
- Removed `k8s`, `nosql`, and `oss` tags

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->