### PR TITLE
display none

### DIFF
--- a/assets/css/eo.scss
+++ b/assets/css/eo.scss
@@ -53,11 +53,13 @@ h1 {
     height: 5em;
 }
 
-@media screen and (max-width: 900px) {
-  .content-desktop {
+@media screen and (max-width: 900px){
+  .quote {
     display: none;
   }
-  .quote {
+}
+
+.quote {
     border-left: 4 * 10px solid darkgreen;
     float: right;
     font-size: 1.6 * 1em;
@@ -65,11 +67,9 @@ h1 {
     margin: .5 * 1em -5 * 1em .5 * 1em 1em;
     padding-left: .75 * 1em;
     width: 15 * 1em;
-
     &::before {
-      content: 'ˮ';
+        content: 'ˮ';
     }
-  }
 }
 
 .subline {

--- a/assets/css/eo.scss
+++ b/assets/css/eo.scss
@@ -53,7 +53,11 @@ h1 {
     height: 5em;
 }
 
-.quote {
+@media screen and (max-width: 900px) {
+  .content-desktop {
+    display: none;
+  }
+  .quote {
     border-left: 4 * 10px solid darkgreen;
     float: right;
     font-size: 1.6 * 1em;
@@ -61,14 +65,11 @@ h1 {
     margin: .5 * 1em -5 * 1em .5 * 1em 1em;
     padding-left: .75 * 1em;
     width: 15 * 1em;
-    @media screen and (max-width: 900px){
-        .content-desktop {
-            display: none;
-        }
-    }
+
     &::before {
-        content: 'ˮ';
+      content: 'ˮ';
     }
+  }
 }
 
 .subline {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added a media query to hide the `.quote` class on screens with a maximum width of 900px.
- Removed the `@media` query that hid the `.content-desktop` class on screens with a maximum width of 900px.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->