### PR TITLE
chore(copyrights): 22

### DIFF
--- a/_latex/altacv.cls
+++ b/_latex/altacv.cls
@@ -1,6 +1,6 @@
 % (The MIT License)
 %
-% Copyright (c) 2024 Aliaksei Bialiauski
+% Copyright (c) 2022-2024 Aliaksei Bialiauski
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the 'Software'), to deal

--- a/_latex/resume.tex
+++ b/_latex/resume.tex
@@ -1,6 +1,6 @@
 % (The MIT License)
 %
-% Copyright (c) 2024 Aliaksei Bialiauski
+% Copyright (c) 2022-2024 Aliaksei Bialiauski
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the 'Software'), to deal
@@ -89,8 +89,8 @@
   About me: hands-on programmer, open source contributor.
   Interested in committing to computer science in the area of ML/AI-powered
   Program Analysis. My next nearest goal is to finish my first research paper
-  in the area of NLP, while ultimate is to get PhD in Machine Learning. I enjoy
-  making music, watching nordic noir, and traveling around the world.
+  in the area of NLP, while ultimate is to get PhD in Machine Learning.
+  I enjoy music, watching movies, and traveling around the world.
   \AtBeginEnvironment{itemize}{\small}
   \columnratio{0.6}
   \begin{paracol}{2}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
The focus of this PR is to update the copyright year in the `altacv.cls` and `resume.tex` files to include 2022-2024.

### Detailed summary
- Updated copyright year in `altacv.cls` and `resume.tex` to 2022-2024.
- Revised interests in `resume.tex` to remove specific hobbies and focus on career goals.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->